### PR TITLE
Add support for getting more than 200 favorites

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -40,6 +40,7 @@ module T
     DEFAULT_NUM_RESULTS = 20
     MAX_SCREEN_NAME_SIZE = 20
     MAX_USERS_PER_REQUEST = 100
+    MAX_NUM_RESULTS = 200
 
     check_unknown_options!
 
@@ -129,7 +130,7 @@ module T
     method_option "reverse", :aliases => "-r", :type => :boolean, :default => false, :desc => "Reverse the order of the sort."
     def direct_messages
       count = options['number'] || DEFAULT_NUM_RESULTS
-      direct_messages = client.direct_messages(:count => count)
+      direct_messages = collect_with_count(:direct_messages, count)
       direct_messages.reverse! if options['reverse']
       if options['csv']
         say ["ID", "Posted at", "Screen name", "Text"].to_csv unless direct_messages.empty?
@@ -163,7 +164,7 @@ module T
     method_option "reverse", :aliases => "-r", :type => :boolean, :default => false, :desc => "Reverse the order of the sort."
     def direct_messages_sent
       count = options['number'] || DEFAULT_NUM_RESULTS
-      direct_messages = client.direct_messages_sent(:count => count)
+      direct_messages = collect_with_count(:direct_messages_sent, count)
       direct_messages.reverse! if options['reverse']
       if options['csv']
         say ["ID", "Posted at", "Screen name", "Text"].to_csv unless direct_messages.empty?
@@ -327,7 +328,7 @@ module T
         end
       end
       count = options['number'] || DEFAULT_NUM_RESULTS
-      statuses = client.favorites(user, :count => count)
+      statuses = collect_with_count(:favorites, count, {:args => [user]})
       print_statuses(statuses)
     end
     map %w(faves favourites) => :favorites
@@ -515,7 +516,7 @@ module T
     method_option "reverse", :aliases => "-r", :type => :boolean, :default => false, :desc => "Reverse the order of the sort."
     def mentions
       count = options['number'] || DEFAULT_NUM_RESULTS
-      statuses = client.mentions(:count => count)
+      statuses = collect_with_count(:mentions, count)
       print_statuses(statuses)
     end
     map %w(replies) => :mentions
@@ -610,7 +611,7 @@ module T
         end
       end
       count = options['number'] || DEFAULT_NUM_RESULTS
-      statuses = client.retweeted_by(user, :count => count)
+      statuses = collect_with_count(:retweeted_by, count, {:args => [user]})
       print_statuses(statuses)
     end
     map %w(rts) => :retweets
@@ -695,9 +696,9 @@ module T
         else
           user.strip_ats
         end
-        statuses = client.user_timeline(user, :count => count)
+        statuses = collect_with_count(:user_timeline, count, {:args => [user]})
       else
-        statuses = client.home_timeline(:count => count)
+        statuses = collect_with_count(:home_timeline, count)
       end
       print_statuses(statuses)
     end

--- a/lib/t/collectable.rb
+++ b/lib/t/collectable.rb
@@ -1,6 +1,8 @@
 module T
   module Collectable
 
+    MAX_NUM_RESULTS = 200
+
     def collect_with_cursor(collection=[], cursor=-1, &block)
       object = yield cursor
       collection += object.collection
@@ -9,9 +11,33 @@ module T
 
     def collect_with_max_id(collection=[], max_id=nil, &block)
       array = yield max_id
+      return collection unless !array.nil?
       collection += array
       array.empty? ? collection : collect_with_max_id(collection, array.last.id - 1, &block)
     end
 
+    def collect_with_count(method, count, opts = {})
+      # Most of the APIs use :count to request a specific count. For the few that don't, this allows
+      # to specify a different count parameter (e.g. search uses :rpp and recommendations uses :limit)
+      count_key = opts[:count_key].nil? ? :count : opts[:count_key]
+      params = {}
+      params[count_key] = MAX_NUM_RESULTS
+      statuses = collect_with_max_id do |max_id|
+        params[:max_id] = max_id unless max_id.nil?
+        params[count_key] = count unless count >= MAX_NUM_RESULTS
+        if count > 0
+          count -= MAX_NUM_RESULTS
+          retryable(:tries => 3, :on => Twitter::Error::ServerError, :sleep => 0) do
+            if opts[:args].nil? || !opts[:args].is_a?(Array) || opts[:args].empty?
+              client.send(method, params)
+            elsif opts[:args].length === 1
+              client.send(method, opts[:args][0], params)
+            elsif opts[:args].length === 2
+              client.send(method, opts[:args][0], opts[:args][1], params)
+            end
+          end
+        end
+      end.flatten.compact
+    end
   end
 end

--- a/lib/t/list.rb
+++ b/lib/t/list.rb
@@ -173,8 +173,8 @@ module T
           owner.strip_ats
         end
       end
-      per_page = options['number'] || DEFAULT_NUM_RESULTS
-      statuses = client.list_timeline(owner, list, :per_page => per_page)
+      count = options['number'] || DEFAULT_NUM_RESULTS
+      statuses = collect_with_count(:list_timeline, count, {:args => [owner, list], :count_key => :per_page})
       print_statuses(statuses)
     end
     map %w(tl) => :timeline

--- a/lib/t/search.rb
+++ b/lib/t/search.rb
@@ -33,8 +33,8 @@ module T
     method_option "long", :aliases => "-l", :type => :boolean, :default => false, :desc => "Output in long format."
     method_option "number", :aliases => "-n", :type => :numeric, :default => DEFAULT_NUM_RESULTS
     def all(query)
-      rpp = options['number'] || DEFAULT_NUM_RESULTS
-      statuses = client.search(query, :rpp => rpp)
+      count = options['number'] || DEFAULT_NUM_RESULTS
+      statuses = collect_with_count(:search, count, {:args => [query], :count_key => :rpp})
       if options['csv']
         say ["ID", "Posted at", "Screen name", "Text"].to_csv unless statuses.empty?
         statuses.each do |status|

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -171,17 +171,33 @@ ID          Posted at     Screen name  Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/direct_messages.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/direct_messages.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/direct_messages.json").
+          with(:query => {:count => "145", :max_id => "1624782205"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.direct_messages
         a_get("/1/direct_messages.json").
           with(:query => {:count => "1"}).
           should have_been_made
       end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.direct_messages
+        a_get("/1/direct_messages.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/direct_messages.json").
+          with(:query => {:count => "145", :max_id => "1624782205"}).
+          should have_been_made
+      end      
     end
     context "--reverse" do
       before do
@@ -276,17 +292,33 @@ ID          Posted at     Screen name  Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/direct_messages/sent.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/direct_messages/sent.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/direct_messages/sent.json").
+          with(:query => {:count => "145", :max_id => "1624782205"}).
+          to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.direct_messages_sent
         a_get("/1/direct_messages/sent.json").
           with(:query => {:count => "1"}).
           should have_been_made
       end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.direct_messages_sent
+        a_get("/1/direct_messages/sent.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/direct_messages/sent.json").
+          with(:query => {:count => "145", :max_id => "1624782205"}).
+          should have_been_made
+      end          
     end
     context "--reverse" do
       before do
@@ -809,15 +841,31 @@ ID                  Posted at     Screen name    Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/favorites.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/favorites.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/favorites.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.favorites
         a_get("/1/favorites.json").
           with(:query => {:count => "1"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.favorites
+        a_get("/1/favorites.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/favorites.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
           should have_been_made
       end
     end
@@ -1789,15 +1837,31 @@ ID                  Posted at     Screen name    Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/statuses/mentions.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/mentions.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/mentions.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.mentions
         a_get("/1/statuses/mentions.json").
           with(:query => {:count => "1"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.mentions
+        a_get("/1/statuses/mentions.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/statuses/mentions.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
           should have_been_made
       end
     end
@@ -2058,15 +2122,31 @@ ID                  Posted at     Screen name    Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/statuses/retweeted_by_me.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/retweeted_by_me.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/retweeted_by_me.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.retweets
         a_get("/1/statuses/retweeted_by_me.json").
           with(:query => {:count => "1"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.retweets
+        a_get("/1/statuses/retweeted_by_me.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/statuses/retweeted_by_me.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
           should have_been_made
       end
     end
@@ -2417,15 +2497,31 @@ ID                  Posted at     Screen name    Text
     end
     context "--number" do
       before do
-        @cli.options = @cli.options.merge("number" => 1)
         stub_get("/1/statuses/home_timeline.json").
           with(:query => {:count => "1"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/home_timeline.json").
+          with(:query => {:count => "200"}).
+          to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/statuses/home_timeline.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @cli.options = @cli.options.merge("number" => 1)
         @cli.timeline
         a_get("/1/statuses/home_timeline.json").
           with(:query => {:count => "1"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @cli.options = @cli.options.merge("number" => 345)
+        @cli.timeline
+        a_get("/1/statuses/home_timeline.json").
+          with(:query => {:count => "200"}).
+          should have_been_made
+        a_get("/1/statuses/home_timeline.json").
+          with(:query => {:count => "145", :max_id => "194546264212385792"}).
           should have_been_made
       end
     end
@@ -2452,6 +2548,36 @@ ID                  Posted at     Screen name    Text
           @cli.timeline("7505382")
           a_get("/1/statuses/user_timeline.json").
             with(:query => {:count => "20", :user_id => "7505382"}).
+            should have_been_made
+        end
+      end
+      context "--number" do
+        before do
+          stub_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "1", :screen_name => "sferik"}).
+            to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+          stub_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "200", :screen_name => "sferik"}).
+            to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+          stub_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "145", :screen_name => "sferik", :max_id => "194546264212385792"}).
+            to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        end
+        it "should limit the number of results to 1" do
+          @cli.options = @cli.options.merge("number" => 1)
+          @cli.timeline("sferik")
+          a_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "1", :screen_name => "sferik"}).
+            should have_been_made
+        end
+        it "should limit the number of results to 345" do
+          @cli.options = @cli.options.merge("number" => 345)
+          @cli.timeline("sferik")
+          a_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "200", :screen_name => "sferik"}).
+            should have_been_made
+          a_get("/1/statuses/user_timeline.json").
+            with(:query => {:count => "145", :screen_name => "sferik", :max_id => "194546264212385792"}).
             should have_been_made
         end
       end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -452,15 +452,31 @@ ID                  Posted at     Screen name    Text
     end
     context "--number" do
       before do
-        @list.options = @list.options.merge("number" => 1)
         stub_get("/1/lists/statuses.json").
           with(:query => {:owner_screen_name => "testcli", :per_page => "1", :slug => "presidents"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/lists/statuses.json").
+          with(:query => {:owner_screen_name => "testcli", :per_page => "200", :slug => "presidents"}).
+          to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_get("/1/lists/statuses.json").
+          with(:query => {:owner_screen_name => "testcli", :per_page => "145", :max_id => "194546264212385792", :slug => "presidents"}).
+          to_return(:body => fixture("empty_array.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @list.options = @list.options.merge("number" => 1)
         @list.timeline("presidents")
         a_get("/1/lists/statuses.json").
           with(:query => {:owner_screen_name => "testcli", :per_page => "1", :slug => "presidents"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @list.options = @list.options.merge("number" => 345)
+        @list.timeline("presidents")
+        a_get("/1/lists/statuses.json").
+          with(:query => {:owner_screen_name => "testcli", :per_page => "200", :slug => "presidents"}).
+          should have_been_made
+        a_get("/1/lists/statuses.json").
+          with(:query => {:owner_screen_name => "testcli", :per_page => "145", :max_id => "194546264212385792", :slug => "presidents"}).
           should have_been_made
       end
     end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -95,15 +95,31 @@ ID                  Posted at     Screen name       Text
     end
     context "--number" do
       before do
-        @search.options = @search.options.merge("number" => 1)
         stub_request(:get, "https://search.twitter.com/search.json").
           with(:query => {:q => "twitter", :rpp => "1"}).
           to_return(:body => fixture("search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_request(:get, "https://search.twitter.com/search.json").
+          with(:query => {:q => "twitter", :rpp => "200"}).
+          to_return(:body => fixture("search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+        stub_request(:get, "https://search.twitter.com/search.json").
+          with(:query => {:q => "twitter", :rpp => "145", :max_id => "194521261307727871"}).
+          to_return(:body => fixture("search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should limit the number of results" do
+      it "should limit the number of results to 1" do
+        @search.options = @search.options.merge("number" => 1)
         @search.all("twitter")
         a_request(:get, "https://search.twitter.com/search.json").
           with(:query => {:q => "twitter", :rpp => "1"}).
+          should have_been_made
+      end
+      it "should limit the number of results to 345" do
+        @search.options = @search.options.merge("number" => 345)
+        @search.all("twitter")
+        a_request(:get, "https://search.twitter.com/search.json").
+          with(:query => {:q => "twitter", :rpp => "200"}).
+          should have_been_made
+        a_request(:get, "https://search.twitter.com/search.json").
+          with(:query => {:q => "twitter", :rpp => "145", :max_id => "194521261307727871"}).
           should have_been_made
       end
     end


### PR DESCRIPTION
Hi

When I was playing with the favorites command, I noticed that it did not retrieve more than the first 200. It seems to be a limitation of the twitter API where it only returns a maximum of 200 favorites per API call. It was a bit confusing as I happen to have more than 200 favorites on my Twitter profile. I was trying to pass `-n 400` to get all my favorites but I kept getting the same first 200.

The twitter gem has a pagination option that allows to work around this limitation. This pull request changes the favorites command to make use of pagination. By default it will query for the first page and if the `-n` option is greater than 200, it will query for subsequent pages. Example: I have 352 favorites. If I call the CLI with `-n 400`, it will request page 1 and then page 2.

What do you think of this behavior? Do you think this behavior should be added to other commands (I noticed other APIs like mentions or timeline have maximum limitations)? 

Note that this pull request is incomplete. I wanted to get your opinion before moving forward. I'd like to clean up:
1) Add tests ;)
2) Fix the issue where it would eventually do more API calls than needed: with my 352 favorites, if I run with `-n 1000`, it will make 5 API calls (1000 divided by 200) but the 3 last calls are useless (the 2 first calls are enough to get all my favorites). 
3) Investigate an odd issue: while the whois command tells me that I have 352 favorites, the favorites command only return 334.
