### PR TITLE
Correct usage for direct_messages_sent

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -167,7 +167,7 @@ module T
     end
     map %w(directmessages dms) => :direct_messages
 
-    desc "direct_messages_sent", "Returns the #{DEFAULT_NUM_RESULTS} most recent Direct Messages sent to you."
+    desc "direct_messages_sent", "Returns the #{DEFAULT_NUM_RESULTS} most recent Direct Messages you've sent."
     method_option "csv", :aliases => "-c", :type => :boolean, :default => false, :desc => "Output in CSV format."
     method_option "long", :aliases => "-l", :type => :boolean, :default => false, :desc => "Output in long format."
     method_option "number", :aliases => "-n", :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => "Limit the number of results."


### PR DESCRIPTION
In writing the zsh completion I noticed a copy/paste error for the usage for `t direct_messages_sent`.
