### PR TITLE
Documentation glitch in 't search'

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@ example, send a user a direct message only if he already follows you:</p>
 
 <h3>Search Tweets in another user's timeline that match a specified query</h3>
 
-<pre><code>t search user @sferik "query"
+<pre><code>t search timeline @sferik "query"
 </code></pre>
 
 <h2>Features</h2>


### PR DESCRIPTION
Hey Erik,

I guess there is a minor issue in the documentation, 't search user @sferik' should be 't search timeline @sferik', shouldn't it?

Thanks for t, like it very much!

Best,
Wolfgang
