### PR TITLE
Fix ZSH completion URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,5 +293,5 @@ Application icon by [@nvk][nvk].
 [license]: https://github.com/sferik/t/blob/master/LICENSE.md
 [nvk]: http://rodolfonovak.com
 [zsh]: http://zsh.org
-[completion]: https://github.com/sferik/t/tree/etc/t-completion.zsh
+[completion]: https://github.com/sferik/t/blob/master/etc/t-completion.zsh
 [contribute]: https://github.com/sferik/t/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
The URL in your readme for ZSH completion pointed to a Github 404, so I tried to fix it.  Might not have been what you intended, but I thought I should point it out.
