### PR TITLE
Adding the ability to specify latitude and longitude from the command line when --location option is supplied.

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -520,9 +520,7 @@ module T
 
     desc "reply TWEET_ID MESSAGE", "Post your Tweet as a reply directed at another person."
     method_option "all", :aliases => "-a", :type => :boolean, :default => false, :desc => "Reply to all users mentioned in the Tweet."
-    method_option "location", :aliases => "-l", :type => :boolean, :default => false
-    method_option "latitude", :aliases => "-A", :type => :numeric, :default => nil, :desc => "Desired latitude for the tweet location. Use with --location."
-    method_option "longitude", :aliases => "-O", :type => :numeric, :default => nil, :desc => "Desired longitude for the tweet location. Use with --location."
+    method_option "location", :aliases => "-l", :type => :string, :default => nil, :desc => "Add location information. If the optional 'latitude,longitude' parameter is not supplied, looks up location by IP address."
     def reply(status_id, message)
       status = client.status(status_id.to_i, :include_my_retweet => false)
       users = Array(status.from_user)
@@ -533,11 +531,7 @@ module T
       require 't/core_ext/string'
       users.map!(&:prepend_at)
       opts = {:in_reply_to_status_id => status.id, :trim_user => true}
-      if options['location']
-        lat = options[:latitude] || location.lat
-        lng = options[:longitude] || location.lng
-        opts.merge!(:lat => lat, :long => lng)
-      end
+      opts = add_location(options, opts)
       reply = client.update("#{users.join(' ')} #{message}", opts)
       say "Reply posted by @#{@rcfile.active_profile[0]} to #{users.join(' ')}."
       say
@@ -744,17 +738,12 @@ module T
     end
 
     desc "update MESSAGE", "Post a Tweet."
-    method_option "location", :aliases => "-l", :type => :boolean, :default => false
-    method_option "latitude", :aliases => "-A", :type => :numeric, :default => nil, :desc => "Desired latitude for the tweet location. Use with --location."
-    method_option "longitude", :aliases => "-O", :type => :numeric, :default => nil, :desc => "Desired longitude for the tweet location. Use with --location."
+    method_option "location", :aliases => "-l", :type => :string, :default => nil, :desc => "Add location information. If the optional 'latitude,longitude' parameter is not supplied, looks up location by IP address."
     method_option "file", :aliases => "-f", :type => :string, :desc => "The path to an image to attach to your tweet."
     def update(message)
       opts = {:trim_user => true}
-      if options['location']
-        lat = options[:latitude] || location.lat
-        lng = options[:longitude] || location.lng
-        opts.merge!(:lat => lat, :long => lng)
-      end
+      opts = add_location(options, opts)
+
       status = if options['file']
         client.update_with_media(message, File.new(File.expand_path(options['file'])), opts)
       else
@@ -877,6 +866,16 @@ module T
 
     def pin_auth_parameters
       {:oauth_callback => 'oob'}
+    end
+
+    def add_location(options, opts)
+      unless options['location'].nil?
+        lat, lng = options['location'].strip.empty? ?
+                      [location.lat, location.lng] :
+                      options['location'].split(',').map(&:to_f)
+        opts.merge!(:lat => lat, :long => lng)
+      end
+      opts
     end
 
     def location

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2012,7 +2012,7 @@ ID                   Posted at     Screen name       Text
 
   describe "#reply" do
     before do
-      @cli.options = @cli.options.merge("profile" => fixture_path + "/.trc", "location" => false)
+      @cli.options = @cli.options.merge("profile" => fixture_path + "/.trc", "location" => nil)
       stub_get("/1.1/statuses/show/263813522369159169.json").with(:query => {:include_my_retweet => "false"}).to_return(:body => fixture("status_with_mention.json"))
       stub_post("/1.1/statuses/update.json").with(:body => {:in_reply_to_status_id => "263813522369159169", :status => "@joshfrench Testing", :trim_user => "true"}).to_return(:body => fixture("status.json"))
       stub_request(:get, "http://checkip.dyndns.org/").to_return(:body => fixture("checkip.html"), :headers => {:content_type => "text/html"})
@@ -2048,7 +2048,7 @@ ID                   Posted at     Screen name       Text
     end
     context "--location" do
       before do
-        @cli.options = @cli.options.merge("location" => true)
+        @cli.options = @cli.options.merge("location" => '')
         stub_get("/1.1/statuses/show/263813522369159169.json").with(:query => {:include_my_retweet => "false"}).to_return(:body => fixture("status_with_mention.json"))
         stub_post("/1.1/statuses/update.json").with(:body => {:in_reply_to_status_id => "263813522369159169", :status => "@joshfrench Testing", :lat => "37.76969909668", :long => "-122.39330291748", :trim_user => "true"}).to_return(:body => fixture("status.json"))
       end
@@ -2064,9 +2064,9 @@ ID                   Posted at     Screen name       Text
         expect($stdout.string.split("\n").first).to eq "Reply posted by @testcli to @joshfrench."
       end
     end
-    context "--location --latitude --longitude" do
+    context "--location 'latitude,longitude'" do
       before do
-        @cli.options = @cli.options.merge("location" => true, "latitude" => "41.03132", "longitude" => "28.9869")
+        @cli.options = @cli.options.merge("location" => "41.03132,28.9869")
         stub_get("/1.1/statuses/show/263813522369159169.json").with(:query => {:include_my_retweet => "false"}).to_return(:body => fixture("status_with_mention.json"))
         stub_post("/1.1/statuses/update.json").with(:body => {:in_reply_to_status_id => "263813522369159169", :status => "@joshfrench Testing", :lat => "41.03132", :long => "28.9869", :trim_user => "true"}).to_return(:body => fixture("status.json"))
       end
@@ -3089,7 +3089,7 @@ WOEID     Parent ID  Type       Name           Country
     end
     context "with just location" do
       before do
-        @cli.options = @cli.options.merge("location" => true)
+        @cli.options = @cli.options.merge("location" => '')
         stub_post("/1.1/statuses/update.json").with(:body => {:status => "Testing", :lat => "37.76969909668", :long => "-122.39330291748", :trim_user => "true"}).to_return(:body => fixture("status.json"))
       end
       it "requests the correct resource" do
@@ -3105,7 +3105,7 @@ WOEID     Parent ID  Type       Name           Country
     end
     context "with location, latitude and longitude" do
       before do
-        @cli.options = @cli.options.merge("location" => true, "latitude" => "41.03132", "longitude" => "28.9869")
+        @cli.options = @cli.options.merge("location" => "41.03132,28.9869")
         stub_post("/1.1/statuses/update.json").with(:body => {:status => "Testing", :lat => "41.03132", :long => "28.9869", :trim_user => "true"}).to_return(:body => fixture("status.json"))
       end
       it "requests the correct resource" do


### PR DESCRIPTION
I had the need to supply the latitude and longitude by hand, so I did some quick updates:
- Added `--latitude` and `--longitude` options (with shorthands `-A` and `-O`) to `update` and `reply` methods. These options are only used if `--location` is supplied.
- Updated the specs for `update` and `reply` so that the baseline case does not have `location` set.
- Added specs checking cases where:
  1. Just `location` is set.
  2. `location`, `latitude` and `longitude` are all set.
