### PR TITLE
Improve Linux instructions: Cover RH-based distros and remove keybinding listing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ If the output looks more like this, you need to [install Ruby][ruby]:
 
     ruby: command not found
 
-**On Linux**, open a Terminal (<kbd>Ctrl+Alt+T</kbd>) and type:
+**On Linux**, for Debian-based systems, open a terminal and type:
 
     sudo apt-get install ruby-dev
+
+or for Red Hat-based distros like Fedora and CentOS, type:
+
+    sudo yum install ruby-devel
 
 (if necessary, adapt for your package manager)
 


### PR DESCRIPTION
Hey there! This PR makes the Linux instructions cover both Debian- and Red-Hat-based systems. I don't know if the package is `ruby-dev` on Debian-based systems, but it's definitely `ruby-devel` on RH-based systems.

Also, I get rid of the keybinding listing, since that's very environment-specific. I can re-add it if you want, but only certain setups have ctrl-alt-t mapped to open a terminal.
