### PR TITLE
Corrected command to sort by last time tweeted

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ example, send a user a direct message only if he already follows you:
     t leaders | xargs t unfollow
 
 #### Unfollow 10 people who haven't tweeted in the longest time
-    t followings -l --sort=tweets | head -10 | awk '{print $1}' | xargs t unfollow -i 
+    t followings -l --sort=tweeted | head -10 | awk '{print $1}' | xargs t unfollow -i 
 
 #### Twitter roulette: randomly follow someone who follows you (who you don't already follow)
     t groupies | shuf | head -1 | xargs t follow


### PR DESCRIPTION
The current command includes `--sort=tweets` to sort users by last time the
users emitted a tweet. However, this parameter sorts by number of user's total tweets.
The correct parameter is `--sort=tweeted`.
