### PR TITLE
Add --relative-dates command line flag

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -125,6 +125,7 @@ module T
     desc 'direct_messages', "Returns the #{DEFAULT_NUM_RESULTS} most recent Direct Messages sent to you."
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     def direct_messages # rubocop:disable CyclomaticComplexity
@@ -157,6 +158,7 @@ module T
     desc 'direct_messages_sent', "Returns the #{DEFAULT_NUM_RESULTS} most recent Direct Messages you've sent."
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     def direct_messages_sent # rubocop:disable CyclomaticComplexity
@@ -190,6 +192,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -282,6 +285,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'max_id', :aliases => '-m', :type => :numeric, :desc => 'Returns only the results with an ID less than the specified ID.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
@@ -319,6 +323,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -339,6 +344,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -359,6 +365,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -387,6 +394,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -415,6 +423,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(members mode since slug subscribers), :default => 'slug', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -435,6 +444,7 @@ module T
     desc 'mentions', "Returns the #{DEFAULT_NUM_RESULTS} most recent Tweets mentioning you."
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     def mentions
@@ -513,6 +523,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     def retweets(user = nil)
@@ -542,6 +553,7 @@ module T
     desc 'status TWEET_ID', 'Retrieves detailed information about a Tweet.'
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     def status(status_id) # rubocop:disable CyclomaticComplexity
       status = client.status(status_id.to_i, :include_my_retweet => false)
       location = if status.place?
@@ -575,7 +587,7 @@ module T
         array << ['ID', status.id.to_s]
         array << ['Text', decode_full_text(status).gsub(/\n+/, ' ')]
         array << ['Screen name', "@#{status.user.screen_name}"]
-        array << ['Posted at', "#{ls_formatted_time(status)} (#{time_ago_in_words(status.created_at)} ago)"]
+        array << ['Posted at', "#{ls_formatted_time(status, :created_at, false)} (#{time_ago_in_words(status.created_at)} ago)"]
         array << ['Retweets', number_with_delimiter(status.retweet_count)]
         array << ['Favorites', number_with_delimiter(status.favorite_count)]
         array << ['Source', strip_tags(status.source)]
@@ -589,6 +601,7 @@ module T
     method_option 'exclude', :aliases => '-e', :type => :string, :enum => %w(replies retweets), :desc => 'Exclude certain types of Tweets from the results.', :banner => 'TYPE'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'max_id', :aliases => '-m', :type => :numeric, :desc => 'Returns only the results with an ID less than the specified ID.'
     method_option 'number', :aliases => '-n', :type => :numeric, :default => DEFAULT_NUM_RESULTS, :desc => 'Limit the number of results.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
@@ -627,6 +640,7 @@ module T
     desc 'trend_locations', 'Returns the locations for which Twitter has trending topic information.'
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(country name parent type woeid), :default => 'name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -696,6 +710,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify input as Twitter user IDs instead of screen names.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :default => false, :desc => 'Reverse the order of the sort.'
     method_option 'sort', :aliases => '-s', :type => :string, :enum => %w(favorites followers friends listed screen_name since tweets tweeted), :default => 'screen_name', :desc => 'Specify the order of the results.', :banner => 'ORDER'
     method_option 'unsorted', :aliases => '-u', :type => :boolean, :default => false, :desc => 'Output is not sorted.'
@@ -719,6 +734,7 @@ module T
     method_option 'csv', :aliases => '-c', :type => :boolean, :default => false, :desc => 'Output in CSV format.'
     method_option 'id', :aliases => '-i', :type => :boolean, :default => false, :desc => 'Specify user via ID instead of screen name.'
     method_option 'long', :aliases => '-l', :type => :boolean, :default => false, :desc => 'Output in long format.'
+    method_option 'relative_dates', :aliases => '-a', :type => :boolean, :desc => 'Show relative dates.'
     def whois(user) # rubocop:disable CyclomaticComplexity
       require 't/core_ext/string'
       user = options['id'] ? user.to_i : user.strip_ats
@@ -729,7 +745,7 @@ module T
       else
         array = []
         array << ['ID', user.id.to_s]
-        array << ['Since', "#{ls_formatted_time(user)} (#{time_ago_in_words(user.created_at)} ago)"]
+        array << ['Since', "#{ls_formatted_time(user, :created_at, false)} (#{time_ago_in_words(user.created_at)} ago)"]
         array << ['Last update', "#{decode_full_text(user.status).gsub(/\n+/, ' ')} (#{time_ago_in_words(user.status.created_at)} ago)"] unless user.status.nil?
         array << ['Screen name', "@#{user.screen_name}"]
         array << [user.verified ? 'Name (Verified)' : 'Name', user.name] unless user.name.nil?

--- a/lib/t/list.rb
+++ b/lib/t/list.rb
@@ -64,7 +64,7 @@ module T
         array << ['Description', list.description] unless list.description.nil?
         array << ['Slug', list.slug]
         array << ['Screen name', "@#{list.user.screen_name}"]
-        array << ['Created at', "#{ls_formatted_time(list)} (#{time_ago_in_words(list.created_at)} ago)"]
+        array << ['Created at', "#{ls_formatted_time(list, :created_at, false)} (#{time_ago_in_words(list.created_at)} ago)"]
         array << ['Members', number_with_delimiter(list.member_count)]
         array << ['Subscribers', number_with_delimiter(list.subscriber_count)]
         array << ['Status', list.following ? 'Following' : 'Not following']

--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -25,10 +25,12 @@ module T
       time.utc.strftime('%Y-%m-%d %H:%M:%S %z')
     end
 
-    def ls_formatted_time(object, key = :created_at)
+    def ls_formatted_time(object, key = :created_at, allow_relative = true)
       return '' if object.nil?
       time = T.local_time(object.send(key.to_sym))
-      if time > Time.now - MONTH_IN_SECONDS * 6
+      if allow_relative && options['relative_dates']
+        distance_of_time_in_words(time) + ' ago'
+      elsif time > Time.now - MONTH_IN_SECONDS * 6
         time.strftime('%b %e %H:%M')
       else
         time.strftime('%b %e  %Y')

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -29,6 +29,69 @@ describe T::CLI do
     $stdout = @old_stdout
   end
 
+  describe '--relative-dates' do
+    before do
+      stub_get('/1.1/statuses/show/55709764298092545.json').with(:query => {:include_my_retweet => 'false'}).to_return(:body => fixture('status.json'))
+      stub_get('/1.1/users/show.json').with(:query => {:screen_name => 'sferik'}).to_return(:body => fixture('sferik.json'))
+      @cli.options = @cli.options.merge('relative_dates' => true)
+    end
+    it 'status has the correct output (absolute and relative date together)' do
+      @cli.status('55709764298092545')
+      expect($stdout.string).to eq <<-eos
+ID           55709764298092545
+Text         The problem with your code is that it's doing exactly what you told it to do.
+Screen name  @sferik
+Posted at    Apr  6  2011 (8 months ago)
+Retweets     320
+Favorites    50
+Source       Twitter for iPhone
+Location     Blowfish Sushi To Die For, 2170 Bryant St, San Francisco, California, United States
+      eos
+    end
+    it 'whois has the correct output (absolute and relative date together)' do
+      @cli.whois('sferik')
+      expect($stdout.string).to eq <<-eos
+ID           7505382
+Since        Jul 16  2007 (4 years ago)
+Last update  @goldman You're near my home town! Say hi to Woodstock for me. (7 months ago)
+Screen name  @sferik
+Name         Erik Michaels-Ober
+Tweets       7,890
+Favorites    3,755
+Listed       118
+Following    212
+Followers    2,262
+Bio          Vagabond.
+Location     San Francisco
+URL          https://github.com/sferik
+      eos
+    end
+    context '--csv' do
+      before do
+        @cli.options = @cli.options.merge('csv' => true)
+      end
+      it 'has the correct output (absolute date in csv)' do
+        @cli.status('55709764298092545')
+        expect($stdout.string).to eq <<-eos
+ID,Posted at,Screen name,Text,Retweets,Favorites,Source,Location
+55709764298092545,2011-04-06 19:13:37 +0000,sferik,The problem with your code is that it's doing exactly what you told it to do.,320,50,Twitter for iPhone,"Blowfish Sushi To Die For, 2170 Bryant St, San Francisco, California, United States"
+        eos
+      end
+    end
+    context '--long' do
+      before do
+        @cli.options = @cli.options.merge('long' => true)
+      end
+      it 'outputs in long format' do
+        @cli.status('55709764298092545')
+        expect($stdout.string).to eq <<-eos
+ID                 Posted at     Screen name  Text                           ...
+55709764298092545  8 months ago  @sferik      The problem with your code is t...
+        eos
+      end
+    end
+  end
+
   describe '#account' do
     before do
       @cli.options = @cli.options.merge('profile' => fixture_path + '/.trc')

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -104,6 +104,22 @@ Mode         public
 URL          https://twitter.com/sferik/presidents
       eos
     end
+    it 'has the correct output with --relative-dates turned on' do
+      @list.options = @list.options.merge('relative_dates' => true)
+      @list.information('presidents')
+      expect($stdout.string).to eq <<-eos
+ID           8863586
+Description  Presidents of the United States of America
+Slug         presidents
+Screen name  @sferik
+Created at   Mar 15  2010 (a year ago)
+Members      2
+Subscribers  1
+Status       Not following
+Mode         public
+URL          https://twitter.com/sferik/presidents
+      eos
+    end
     context 'with a user passed' do
       it 'requests the correct resource' do
         @list.information('testcli/presidents')


### PR DESCRIPTION
Create --relative-dates command line flag which causes relative dates to be shown in all places when the flag is passed, except for CSV output, and places where an absolute and relative data were already shown together. Fixes issue #136.

I'll admit being motivated by the http://tip4commit.com/, but I thought solving an existing issue would still be helpful. Very nice project to hack on BTW; only took me 40 minutes, so thanks.
