### PR TITLE
more proper "following" list creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ example, here's how to send a user a direct message only if they already follow 
 #### Create a list for everyone you're following
     t list create following-`date "+%Y-%m-%d"`
 
-#### Add everyone you're following to that list (up to 500 users)
-    t followings | xargs t list add following-`date "+%Y-%m-%d"`
+#### Add everyone you're following to that list
+    t followings | xargs -n 100 t list add following-`date "+%Y-%m-%d"`
 
 #### List all the members of a list, in long format
     t list members -l following-`date "+%Y-%m-%d"`


### PR DESCRIPTION
Twitter has a restriction of max. 100 users added to a list
per API request. Splitting the output of `t followings` into
100-user chunks and adding each chunk separately will allow
to add any number of users to the list.
