### PR TITLE
Adding mobile number to Twitter account for international users

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ messages", otherwise you'll receive an error that looks like this:
 
     Error processing your OAuth request: Read-only application cannot POST
 
+A mobile phone number must be associated with your account in order to obtain write privileges. If your carrier is not supported by Twitter and you are unable to add a number, contact Twitter using <https://support.twitter.com/forms/platform>, selecting the last checkbox. Some users have reported success adding their number using the mobile site, <https://mobile.twitter.com/settings>, which seems to bypass the carrier check at the moment.
+
 Now, you're ready to authorize a Twitter account with your application. To
 proceed, type the following command at the prompt and follow the instructions:
 


### PR DESCRIPTION
I ran into an error when trying to configure my Twitter application - I needed to add a mobile number in order to get write privileges for my Twitter app (see https://support.twitter.com/articles/110250-adding-your-mobile-number-to-your-account), but my local carrier was not recognized by Twitter and I was unable to add the number. Apparently this is common for Twitter users located outside the United States (I'm located in Israel).

I looked around for solutions to this, and officially, Twitter recommends contacting them for assistance. Unofficially, and what worked for me, was accessing the setting using the Twitter mobile site, and adding the number there. This seems to bypass the carrier check. I was thinking that the documentation should be updated to reflect these suggestions, although I'm not sure it's a good idea to recommend using what seems to be a bug on Twitter's part. 

An alternative solution could be just to warn new users of this potential issue.
