### PR TITLE
Fixing broken link in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,5 @@ Ideally, a bug report should include a pull request with failing specs.
 9. [Submit a pull request.][pr]
 
 [fork]: http://help.github.com/fork-a-repo/
-[branch]: http://learn.github.com/p/branching.html
+[branch]: http://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [pr]: http://help.github.com/send-pull-requests/


### PR DESCRIPTION
The link "http://learn.github.com/p/branching.html" no longer works. I
searched to see any other resources for learn.github.com but could not
find anything. I changed the link to point to the github help page for
creating and deleting branches.
