### PR TITLE
Print a friendly error when running whoami without authorizing first

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -925,8 +925,12 @@ module T
     method_option 'long', aliases: '-l', type: :boolean, desc: 'Output in long format.'
     method_option 'relative_dates', aliases: '-a', type: :boolean, desc: 'Show relative dates.'
     def whoami
-      user = @rcfile.active_profile[0]
-      whois(user)
+      if @rcfile.active_profile && @rcfile.active_profile[0]
+        user = @rcfile.active_profile[0]
+        whois(user)
+      else
+        $stderr.puts "You haven't authorized an account, run `t authorize` to get started."
+      end
     end
 
     desc 'delete SUBCOMMAND ...ARGS', 'Delete Tweets, Direct Messages, etc.'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -4178,6 +4178,14 @@ ID       Since         Last tweeted at  Tweets  Favorites  Listed  Following ...
         eos
       end
     end
+    context 'no configuration' do
+      it 'prints a helpful message and no errors' do
+        T::RCFile.instance.path = ''
+        @cli = T::CLI.new
+        @cli.whoami
+        expect($stderr.string).to eq "You haven't authorized an account, run `t authorize` to get started.\n"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
New users who run `t whoami` without running `t authorize` first
currently see a nasty error:

```
spectre256@laguna ~ $ t whoami
/home/spectre256/.gem/ruby/2.1.0/gems/t-2.8.0/lib/t/cli.rb:928:in `whoami': undefined method `[]' for nil:NilClass (NoMethodError)
    from /home/spectre256/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /home/spectre256/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /home/spectre256/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /home/spectre256/.gem/ruby/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /home/spectre256/.gem/ruby/2.1.0/gems/t-2.8.0/bin/t:20:in `<top (required)>'
    from /home/spectre256/.gem/ruby/2.1.0/bin/t:23:in `load'
    from /home/spectre256/.gem/ruby/2.1.0/bin/t:23:in `<main>'
```

Now instead they'll see a friendly, helpful message

```
spectre256@laguna ~/repos/t $ bundle exec t whoami
You haven't authorized an account, run `t authorize` to get started.
```

I'm happy to make any tweaks if there are preferences for setting up the test, checking for valid configuration, or printing to stderr. Thanks!
