### PR TITLE
Don't try to sort_by unnamed users

### DIFF
--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -184,6 +184,5 @@ module T
     def safe_screen_name(user)
       user.screen_name.is_a?(Twitter::NullObject) ? '' : user.screen_name.downcase
     end
-
   end
 end


### PR DESCRIPTION
I know there is a fix in the Twitter gem for making Twitter::NullObject comparable but I was still running into errors attempting to fetch my followings:

```
/Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/t-2.8.0/lib/t/printable.rb:164:in `sort_by': comparison of String with Twitter::NullObject failed (ArgumentError)
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/t-2.8.0/lib/t/printable.rb:164:in `print_users'
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/t-2.8.0/lib/t/cli.rb:325:in `followings'
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/njero/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from bin/t:20:in `<main>'
```

The source of the error was in the `sort_by` for `screen_name`. One of the people I follow is "Mysteriously Unnamed" meaning they have a Twitter::NullObject for a screen_name (see: [https://twitter.com/intent/user?user_id=27371960](https://twitter.com/intent/user?user_id=27371960)) and this causes all kinds of havoc. 

![screen shot 2014-12-09 at 12 11 12 pm](https://cloud.githubusercontent.com/assets/4064/5364921/8540b1f4-7f9c-11e4-82ef-1cdd278e62ec.png)

I was able to use the `t` gem to find the id of the user so that I could unfollow them (which I haven't done yet in case I need to test more things), but I also added a fix for the `sort_by` so that there is no failure. There might be a better / more general approach for this.
